### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,32 +6,32 @@ Allows the user to download songs by entering in a song title which will include
 
 Note: If your song isn't being properly searching, try adding song **title** and **artist**. To strengthen search further, add **album name**.
 
-#####How it works? :
+##### How it works? :
    - It uses the itunes search to grab the metadata that the user has requested
    - Use Pleer.com to find and download corresponding song
    
-#####Features:
+##### Features:
    - Shows a list of songs from the search made
    - Filters through high, low, or VBR bitrates
    - Ability to play songs within the browser
    - Quick download to quickly download to instantly download the first search result
 
-#####Song List:
+##### Song List:
 Filter through the songs using the `<` and `>` keys once shown.
 
-#####Settings:
+##### Settings:
    - Click on the Settings button on the top left to access settings
    - Set directory
    - Change song filter quality
    
 <img src="https://raw.github.com/sacert/SoundSea/master/SettingsWindow.png" width="400" height="171"/>
 
-#####Play Song:
+##### Play Song:
    - Hit the play button on the bottom left of the album art
    - Hit again to pause the song
    - If changed song from list, pause and start the song again to play the current song in the list
 
-#####Working on:
+##### Working on:
    - Cleaning up code - as of right now there are a ton of global variables that I want to remove and lines of code that are called multiple times, it is best to make functions out of them
    - Bug fixing - need to play around with it more for certain bugs to pop up
    - Tighten the searching algorithm


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
